### PR TITLE
Hide split view heading and pill markers without hiding avatar

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,4 +1,6 @@
-/* button:has(div):has(div):has(div):has(div):has(svg), */
-div[data-testid="split-stays"] {
+button:has(div):has(div):has(div):has(div):has(svg[aria-label="Split stay"]),
+div[data-testid="split-stays"],
+.t1wk5n1c,
+.sbylqvx {
   display: none !important;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This selects the split view buttons in the map and in the list to remove both from the DOM. It also selects the heading and subheading that appear in the list view. 

<!--- Describe your changes in detail -->

## Background
I decided to create this extension because I noticed there's no option to disable split stays - these are stays in multiple places for a set amount of time. For example, if you're looking for a place to stay in London for two weeks, it'll show you two places to stay at for two weeks instead of one stay that's available for the full two weeks. I wanted to give users the option to hide this if they'd like. 

I held off on creating this extension for a while because I didn't know of a way to select a parent element that has a specific child - the split-stay buttons have the exact same classes as the regular buttons in the map view - but after learning about the [:has css selector](https://css-tricks.com/the-css-has-selector/) I was able to implement this. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by following the instructions in the [README](https://www.github.com/garnetred/airbnb-no-splitview/main/blob/README.md) to load an unpacked extension in chrome.

After the extension has been enabled, you can navigate to Airbnb, search for a stay in any city for a duration of time, and zoom in on the map until there are few stays available. You should not see any split stays. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
Before:
![airbnbnosplitview_before2](https://github.com/garnetred/airbnb-no-splitview/assets/59572865/81f23961-e4a6-4ef3-a412-278c65cf095e)

![airbnbnosplitview_before1](https://github.com/garnetred/airbnb-no-splitview/assets/59572865/34391944-ff1a-42f1-84b8-49283f5b1b0b)

After:
![airbnbnosplitview_after1](https://github.com/garnetred/airbnb-no-splitview/assets/59572865/cb0579a8-b20b-496c-a35a-f88cef5c0ccb)

![airbnbnosplitview_after2](https://github.com/garnetred/airbnb-no-splitview/assets/59572865/2756c586-888c-4e4d-a95f-c8c530476e82)

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
